### PR TITLE
added more top-level-project handling to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,24 @@ message(STATUS "${BoldGreen}----------------------------------------")
 
 # ------------------------------------------------------------------------------
 
+if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  message(STATUS "exa is top-level project")
+  set(IS_TOP_LEVEL_PROJECT true)
+else()
+  message(STATUS "exa was called from other project with add_subdirectory()")
+  set(IS_TOP_LEVEL_PROJECT false)
+endif()
+
+# ------------------------------------------------------------------------------
+
 # this should only be set to true, if you want to run the tests
 if (NOT DEFINED EXA_UNIT_TESTS)
-  set(EXA_UNIT_TESTS true)
+  if (${IS_TOP_LEVEL_PROJECT})
+    set(EXA_UNIT_TESTS true)
+  else()
+    message(STATUS "exa tests are disabled")
+    set(EXA_UNIT_TESTS false)
+  endif()
 endif()
 
 # set the following to true, if you want the tests to output the errors to cerr
@@ -87,7 +102,7 @@ endif()
 
 # ------------------------------------------------------------------------------
 
-message(STATUS "${BoldGreen}------- configuring libraries")
+message(STATUS "${BoldGreen}------- configuring libraries for exa")
 
 if (EXA_UNIT_TESTS)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -96,26 +111,25 @@ endif()
 
 add_subdirectory(libs)
 
-message(STATUS "${BoldGreen}------- configuring libraries done")
+message(STATUS "${BoldGreen}------- configuring libraries done for exa")
 
 # ------------------------------------------------------------------------------
 
-if (EXA_UNIT_TESTS)
-  include_directories(
-    ${LIBS_INCLUDE_DIRS}
-    ${EXA_INCLUDE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests
-  )
-else ()
-  include_directories(
-    ${LIBS_INCLUDE_DIRS}
-    ${EXA_INCLUDE_DIR}
-  )
-endif ()
+set(EXA_INCLUDE_DIRS
+  ${LIBS_INCLUDE_DIRS}
+  ${EXA_INCLUDE_DIR}
+)
+
+if (NOT ${IS_TOP_LEVEL_PROJECT})
+  set(EXA_INCLUDE_DIRS ${EXA_INCLUDE_DIRS} PARENT_SCOPE)
+endif()
 
 # ------------------------------------------------------------------------------
 
 add_library(exa STATIC ${EXA_SRC_FILES} ${LIBS_SRC_FILES})
+target_include_directories(exa PRIVATE
+  ${EXA_INCLUDE_DIRS}
+)
 target_link_libraries(exa
   ${EXA_LIBS}
 )
@@ -126,6 +140,10 @@ if (EXA_UNIT_TESTS)
   add_executable(
     ExaTests
       ${EXA_TESTS_FILES}
+  )
+  target_include_directories(ExaTests PRIVATE
+    ${EXA_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests
   )
   target_link_libraries(ExaTests gmock_main exa)
   add_test(ExaTests ${CMAKE_CURRENT_SOURCE_DIR}/build/ExaTests)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # exa
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-brightgreen.svg)](https://semver.org/)
+[![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-brightgreen.svg)](https://semver.org/)
 [![Build Status](https://travis-ci.org/progsource/exa.svg?branch=master)](https://travis-ci.org/progsource/exa)
 
 **exa** is a short name for **extended assert**.
@@ -39,10 +39,20 @@ message, which is written to `std::cerr`, differs based on the level.
 Clone the repository and run `git submodule update --init --recursive` to get
 the dependencies.
 
-Add `libs/fmt`, `include/exa/exa.h` and `src/exa/exa.cpp` to your files to
+### with cmake
+
+Add it as a submodule itself, initialize it recursively and add it to your
+`CMakeLists.txt` with `add_subdirectory(exa)` + adding the fmtlib and exa header
+to your include directories with the variable `${EXA_INCLUDE_DIRS}`.
+
+### without cmake
+
+Add `libs/fmt` files, `include/exa/exa.h` and `src/exa/exa.cpp` to your files to
 compile.
 
-Then you can use it for example like:
+### in code
+
+You can use it for example like:
 
 ```c++
 #include "exa/exa.h"


### PR DESCRIPTION
If exa is not the top-level-project, the include directories are
now available as EXA_INCLUDE_DIRS to the calling CMakeLists.txt.